### PR TITLE
fix: Export `DartAnalyzeLogTypeEnum`

### DIFF
--- a/.changeset/late-wings-feel.md
+++ b/.changeset/late-wings-feel.md
@@ -1,0 +1,5 @@
+---
+'dart-analyze': patch
+---
+
+Export DartAnalyzeLogTypeEnum

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { run } from './action.js';
+export { DartAnalyzeLogTypeEnum } from './analyze/DartAnalyzeLogType.js';
 export type { ActionOptions } from './utils/ActionOptions.js';
 export { FailOnEnum } from './utils/FailOn.js';


### PR DESCRIPTION
This pull request makes a minor change to the package's exports by exposing the `DartAnalyzeLogTypeEnum` from the main entry point. This allows consumers of the package to directly import this enum.

* Exposed the `DartAnalyzeLogTypeEnum` from `src/analyze/DartAnalyzeLogType.js` in the main `src/index.ts` export, making it available for external use.
* Added a changeset file documenting the export of `DartAnalyzeLogTypeEnum`.